### PR TITLE
docs: 添加详细 README 文档

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,108 +5,316 @@
 [![Latest Release](https://img.shields.io/github/v/release/Dragon-Git/icdk?color=blue&label=Latest%20Release)](https://github.com/Dragon-Git/icdk/releases/latest)
 [![downloads](https://pepy.tech/badge/uvmgen)](https://pepy.tech/project/uvmgen)
 [![CI](https://github.com/Dragon-Git/icdk/actions/workflows/python-package.yml/badge.svg)](https://github.com/Dragon-Git/icdk/actions/workflows/python-package.yml)
+[![codecov](https://codecov.io/gh/Dragon-Git/icdk/graph/badge.svg?token=ICDK)](https://codecov.io/gh/Dragon-Git/icdk)
 ![GitHub deployments](https://img.shields.io/github/deployments/Dragon-Git/icdk/release)
 
 ---
 ## Introduction
-uvmgen includes a uvm testbench generation tool `uvmgen` and an experimental code snippets generation tool `sudef`.
 
-- `uvmgen` is a command-line interface (CLI) program for generating testbench structures based on a provided JSON/YAML/TOML/XML configuration file. 
-- `sudef` is an command-line tool designed to process SystemVerilog files containing mako-style templates. By parsing specific comment formats, sudef generates SystemVerilog code that adheres to the defined templates.
+**icdk** (IC Development Toolkit) is a Python-based toolkit that accelerates UVM (Universal Verification Methodology) testbench development. It ships two CLI utilities:
+
+| Tool | Description |
+|------|-------------|
+| **`uvmgen`** | Generates a complete UVM testbench directory tree from a JSON/YAML/TOML/XML configuration file. |
+| **`sudef`** | Expands `super_define` Mako templates embedded in SystemVerilog comments to produce repetitive SV code. |
+
+### Key Features
+
+- **Multi-format configuration** — JSON, YAML, TOML, and XML are all supported.
+- **Template-driven** — All output is rendered from [Mako](https://www.makotemplates.org/) templates that you can customize.
+- **Modular packages** — Generate a full testbench or individual packages (agent, env, RAL, seq_lib, test, tb_lib).
+- **Third-party integration** — Optional support for [SyoSil UVM Scoreboard](https://github.com/Dragon-Git/uvm_syoscb), [svlib](https://github.com/Dragon-Git/svlib), and [cluelib](https://github.com/Dragon-Git/cluelib).
+- **Python 3.9 – 3.13** — Tested across CPython 3.9 through 3.13 on Linux, macOS, and Windows.
+
 ## Installing
+
 <details>
   <summary>Prerequisites</summary>
 
-- Operating systems
-  - Windows
-  - Linux
-  - macOS
-- Python: 3.9 ~ 3.13
+- **Operating systems**: Windows, Linux, macOS
+- **Python**: 3.9 – 3.13
 </details>
 
-Use Python's package installer pip to install uvmgen:
+Install from PyPI:
+
 ```bash
-python3 -m pip install uvmgen 
+python3 -m pip install uvmgen
 ```
 
-## uvmgen - uvm testbench generator
+Or install from source for development:
 
-### Usage
-
-The basic usage of uvmgen is as follows:
 ```bash
-uvmgen --input <input_cfg_file> --output <output_directory>
+git clone https://github.com/Dragon-Git/icdk.git
+cd icdk
+python3 -m pip install -e '.[dev]'
 ```
 
-### Options
+---
 
-- `--input <input_cfg_file>`: Specifies the input configuration file containing the configuration for the testbench structure.  
-- `--output <output_directory>`: Specifies the directory where the generated files will be placed.
+## uvmgen — UVM Testbench Generator
 
-### Help
-
-For additional help and options, you can use the -h or --help option:
+### Quick Start
 
 ```bash
+uvmgen --input <config_file> --output <output_directory>
+```
+
+| Option | Short | Description |
+|--------|-------|-------------|
+| `--input` | `-i` | Path to the configuration file (JSON/YAML/TOML/XML). |
+| `--output` | `-o` | Output directory (default: `tb`). |
+
+```bash
+# Generate a full testbench
+uvmgen -i testbench_config.json -o tb
+
+# Use default output directory "tb"
+uvmgen -i testbench_config.json
+
+# Show help
 uvmgen -h
 ```
 
-### Optional libraries
+### Configuration File Format
 
-- SyoSil ApS UVM Scoreboard  
-The [SyoSil ApS UVM Scoreboard](https://github.com/Dragon-Git/uvm_syoscb) is a feature of uvmgen that allows you to integrate SyoSil ApS UVM Scoreboard in environments. To use this feature, you need to add `pk_syoscb` to `import_pkgs` of env_pkg, and set the `SYOSCB_HOME` environment variables to SyoSil ApS UVM Scoreboard installed directory. The bash command is printed after uvmgen is successful, and the other shells can be replaced with the corresponding commands.
+Every configuration file is a mapping of **package name → package definition**. Each package definition has three keys:
 
-- svlib  
-svlib is a free, open-source library of utility functions for SystemVerilog. It includes file and string manipulation functions, full regular expression search/replace, easy reading and writing of configuration files, access to environment variables and wall-clock time, and much more.
+| Key | Type | Description |
+|-----|------|-------------|
+| `description` | `str` | Human-readable description (not used in code generation). |
+| `type` | `str` | Template group identifier. Must match a sub-directory under `templates/`. |
+| `vars` | `dict` | Variables passed to the Mako template renderer. |
 
-- cluelib  
-ClueLib is a free, open-source generic library written in SystemVerilog.
-### Example
+#### Supported Package Types
 
-Suppose you have a JSON configuration file named testbench_config.json and you want to generate the testbench structure in a directory named tb, you would run the following command:
+| `type` | Template directory | Generated files |
+|--------|--------------------|-----------------|
+| `agt_pkg` | `templates/agt_pkg/` | agent, driver, monitor, sequencer, item, config, coverage, interface, reg_adapter, mon2cov_connect, pkg |
+| `env_pkg` | `templates/env_pkg/` | env, env_cfg, scoreboard, virtual sequencer, pkg |
+| `ral_pkg` | `templates/ral_pkg/` | register abstraction layer pkg |
+| `seq_lib_pkg` | `templates/seq_lib_pkg/` | base_seq, seq, seq_lib, vseq, pkg |
+| `test_pkg` | `templates/test_pkg/` | base_test, test_builder, pkg |
+| `tb_lib` | `templates/tb_lib/` | top-level tb module, filelist |
+
+#### Configuration Examples
+
+The same configuration can be expressed in any of the four supported formats:
+
+**JSON** (`.json`):
+```json
+{
+    "spi_agt_pkg": {
+        "description": "SPI agent package",
+        "type": "agt_pkg",
+        "vars": {
+            "pkg_name": "spi_agt_pkg",
+            "import_pkgs": [],
+            "agent_name": "spi",
+            "drv_type": "pull",
+            "drv_export_type": "block",
+            "mon2cov_con_method": "analysis_port"
+        }
+    }
+}
+```
+
+**YAML** (`.yaml`):
+```yaml
+spi_env_pkg:
+  description: SPI env package
+  type: env_pkg
+  vars:
+    pkg_name: spi_env_pkg
+    import_pkgs:
+      - spi_agt_pkg
+      - ral_pkg
+    env_name: spi_env
+    env_childs:
+      m_spi_agt: spi_agt
+    scb_name: spi_scb
+    vsqr_name: spi_vsqr
+    has_regmodel: True
+    ral_block_name: empty_reg_block
+    reg_agt_name: m_spi_agt
+    mon2cov_con_method: analysis_port
+```
+
+**TOML** (`.toml`):
+```toml
+[spi_tb_lib]
+  description = "SPI test package"
+  type = "tb_lib"
+
+[spi_tb_lib.vars]
+  pkg_name = "spi_tb_lib"
+  import_pkgs = ["spi_test_pkg"]
+  if_name = "spi_if"
+  filelist_pkgs = ["spi_agt_pkg", "spi_ral_pkg", "spi_env_pkg", "spi_seq_lib_pkg", "spi_test_pkg", "spi_tb_lib"]
+```
+
+**XML** (`.xml`):
+```xml
+<spi_ral_pkg>
+    <description>SPI ral package</description>
+    <type>ral_pkg</type>
+    <vars>
+        <pkg_name>spi_ral_pkg</pkg_name>
+    </vars>
+</spi_ral_pkg>
+```
+
+### Common Template Variables
+
+The `vars` dict varies by package type. Below is a reference for the most commonly used variables:
+
+| Variable | Used by | Description |
+|----------|---------|-------------|
+| `pkg_name` | all | Package name (used in `` `include `` and class names). |
+| `import_pkgs` | all | List of packages to import. |
+| `agent_name` | `agt_pkg` | Base name for agent classes (e.g. `spi_agt`, `spi_drv`). |
+| `drv_type` | `agt_pkg` | Driver type: `"pull"` or `"push"`. |
+| `drv_export_type` | `agt_pkg` | Driver export type: `"block"` or other. |
+| `mon2cov_con_method` | `agt_pkg` | Monitor-to-coverage connection: `"analysis_port"` or `"callback"`. |
+| `env_name` | `env_pkg`, `test_pkg` | Environment class name. |
+| `env_childs` | `env_pkg` | Dict of child component instances. |
+| `scb_name` | `env_pkg` | Scoreboard name. |
+| `vsqr_name` | `env_pkg`, `seq_lib_pkg` | Virtual sequencer name. |
+| `has_regmodel` | `env_pkg` | Whether to include register model integration. |
+| `ral_block_name` | `env_pkg` | Register block name. |
+| `seq_lib_name` | `seq_lib_pkg`, `test_pkg` | Sequence library name. |
+| `seq_name` | `seq_lib_pkg` | Sequence name. |
+| `vseq_name` | `seq_lib_pkg`, `test_pkg` | Virtual sequence name. |
+| `test_name` | `test_pkg` | Base test class name. |
+| `seq_start_method` | `test_pkg` | Method to start the virtual sequence. |
+| `if_name` | `tb_lib` | Top-level interface name. |
+| `filelist_pkgs` | `tb_lib` | Ordered list of packages for the filelist. |
+
+### Generated Output Structure
+
+Running `uvmgen -i typical.json -o tb` produces:
+
+```
+tb/
+├── spi_agt_pkg/
+│   ├── spi_agt_pkg.gen.sv
+│   ├── spi_agt.gen.sv
+│   ├── spi_cfg.gen.sv
+│   ├── spi_cov.gen.sv
+│   ├── spi_drv.gen.sv
+│   ├── spi_if.gen.sv
+│   ├── spi_item.gen.sv
+│   ├── spi_mon.gen.sv
+│   ├── spi_mon2cov_connect.gen.sv
+│   ├── spi_reg_adapter.gen.sv
+│   └── spi_sqr.gen.sv
+├── typical_env_pkg/
+│   ├── typical_env_pkg.gen.sv
+│   ├── typical_env.gen.sv
+│   ├── typical_env_cfg.gen.sv
+│   ├── typical_scb.gen.sv
+│   └── typical_vsqr.gen.sv
+├── typical_ral_pkg/
+│   └── typical_ral_pkg.gen.sv
+├── typical_seq_lib_pkg/
+│   ├── typical_seq_lib_pkg.gen.sv
+│   ├── spi_base_seq.gen.sv
+│   ├── spi_seq.gen.sv
+│   ├── spi_seq_lib.gen.sv
+│   └── typical_vseq.gen.sv
+├── typical_test_pkg/
+│   ├── typical_test_pkg.gen.sv
+│   ├── spi_base_test.gen.sv
+│   └── spi_test_builder.gen.sv
+└── typical_tb_lib/
+    ├── tb.gen.sv
+    └── filelist.f
+```
+
+### Running the Generated Testbench
+
+The generated `filelist.f` can be used directly with major simulators:
 
 ```bash
-uvmgen --input testbench_config.json --output tb
-# or
-uvmgen -i testbench_config.json -o tb
-# or
-uvmgen -i testbench_config.json
+# Synopsys VCS
+vcs -sverilog -full64 -ntb_opts <uvm_version> \
+    -f tb/typical_tb_lib/filelist.f \
+    -R +UVM_TESTNAME=base_test +UVM_TEST_SEQ=typical_vseq
+
+# Cadence Xcelium
+xrun -sv -64bit -uvmhome <uvm_version> \
+    -f tb/typical_tb_lib/filelist.f \
+    +UVM_TESTNAME=base_test +UVM_TEST_SEQ=typical_vseq
 ```
 
-You can use `test/json/example/typical.json` to generate a complete UVM environment, or use `test/json/base_pkg/***.***` to generate a single package.  
-The command to run base tb generated from `test/json/example/typical.json` is:
-```bash                                                                                                                        
-vcs -sverilog -full64 -ntb_opts <uvm version> -f tb/typical_tb_lib/filelist.f -R +UVM_TESTNAME=base_test +UVM_TEST_SEQ=typical_vseq
-# <uvm version> is one of uvm-1.1,uvm-1.2,uvm-ieee,uvm-ieee-2020.
-# or
-xrun -sv -64bit -uvmhome <uvm version> -f tb/typical_tb_lib/filelist.f +UVM_TESTNAME=base_test +UVM_TEST_SEQ=typical_vseq
-# <uvm version> is one of CDNS-1.1d,CDNS-1.2,CDNS-IEEE.
+> `<uvm_version>` for VCS: `uvm-1.1`, `uvm-1.2`, `uvm-ieee`, `uvm-ieee-2020`  
+> `<uvm_version>` for Xcelium: `CDNS-1.1d`, `CDNS-1.2`, `CDNS-IEEE`
+
+### Optional Libraries
+
+#### SyoSil UVM Scoreboard
+
+The [SyoSil ApS UVM Scoreboard](https://github.com/Dragon-Git/uvm_syoscb) can be integrated into generated environments:
+
+1. Add `"pk_syoscb"` to `import_pkgs` in your `env_pkg` configuration.
+2. Set the `SYOSCB_HOME` environment variable to the installed directory.
+
+After generation, `uvmgen` prints the required environment variables:
+
+```bash
+export SYOSCB_HOME=/path/to/uvm_syoscb
+export TB_PATH=/path/to/tb
 ```
 
+#### svlib
 
-## sudef - SV File Template Generator
+[svlib](https://github.com/Dragon-Git/svlib) is a free, open-source library of utility functions for SystemVerilog, including file/string manipulation, regex search/replace, configuration file I/O, and more.
+
+#### cluelib
+
+[cluelib](https://github.com/Dragon-Git/cluelib) is a free, open-source generic utility library written in SystemVerilog.
+
+### Custom Templates
+
+Templates are [Mako](https://docs.makotemplates.org/) `.mako.sv` files located under `src/uvmgen/templates/`. To use custom templates:
+
+1. Create a template directory with the same structure (e.g. `my_templates/agt_pkg/agt.mako.sv`).
+2. Pass the directory path to the `UVMGen` constructor:
+
+```python
+from uvmgen.uvmgen import UVMGen
+
+gen = UVMGen(template_path="my_templates")
+gen.gen("config.json", "tb")
+```
+
+Template files use the `.mako.sv` extension and can reference any variable from the `vars` dict in the configuration file. Files with `pkg` in their name are rendered last, allowing them to reference previously generated files.
+
+---
+
+## sudef — SV File Template Generator
 
 ### Overview
 
-sudef is a command-line tool designed to process SystemVerilog (.sv) files that contain mako-style templates in comments. The tool generates code based on the provided templates, supporting both inline code generation and the inclusion of external files. By invoking sudef <svfile>, you can automatically generate the desired SystemVerilog code based on the specified template definitions.
+`sudef` is a command-line tool that processes SystemVerilog (`.sv`/`.svh`) files containing Mako-style templates in comments. It expands `super_define()` blocks into rendered SystemVerilog code.
 
 ### Usage
 
-The basic usage of sudef is as follows:
 ```bash
 sudef <input>
 ```
-where `<input>` is the path to the SystemVerilog file or directory, and if `<input>` is a directory, sudef will process all .sv files in the directory and subdirectories.
-- Inline Mode  
-When `super_define()` is called with no arguments, sudef operates in inline mode. In this mode, the generated code is directly inserted into the original .sv file, replacing the template placeholders with the appropriate values.
-- External File Mode  
-When `super_define()` is called with arguments, sudef enters external file mode. In this mode, the generated code is written to a separate external file. The path and name of the external file are specified as arguments to `super_define()`.
-### Experimental Nature
-Due to its experimental nature, sudef may contain features that are not yet fully tested. You may encounter unexpected behavior or errors during usage. We encourage you to report any issues or suggested improvements to help us continually improve this program.
+
+Where `<input>` is a file or directory path. If a directory is given, `sudef` recursively processes all `.sv`/`.svh` files within it.
+
+### Two Modes
+
+| Mode | Syntax | Behavior |
+|------|--------|----------|
+| **Inline** | `/* super_define() ... */` | Rendered code is inserted directly into the original file. |
+| **External file** | `/* super_define(filename.svh) ... */` | Rendered code is written to the specified file; an `` `include `` directive replaces the template block. |
 
 ### Example
 
-Let's consider a simple example where we have a SystemVerilog file named example.sv that contains a mako template:
+**Input** (`example.sv`):
 ```systemverilog
 /* super_define()
 <%
@@ -124,11 +332,13 @@ int cfg_${i};
 
 */
 ```
-You can use sudef to generate the code by running:
+
+**Run**:
 ```bash
 sudef example.sv
 ```
-The generated code will be:
+
+**Output** (`example.sv`, modified in-place):
 ```systemverilog
 /* super_define()
 <%
@@ -157,25 +367,84 @@ int cfg_2;
 `uvm_object_utils_end
 // super_define generate end
 ```
-If you want to generate the code to an external file, you can use super_define() with arguments:
-```systemverilog
-/* super_define(cfg_inc.svh)
-<%
 
-%>\
-% for i in range(3):
-int cfg_${i};
-% endfor
+**External file mode** — use `super_define(cfg_inc.svh)` to write the generated code to `cfg_inc.svh` and replace the block with an `` `include `` directive.
 
-`uvm_object_utils_begin(mycfg)
-% for i in range(3):
-`uvm_field_int(cfg_${i}, UVM_DEFAULT)
-% endfor
-`uvm_object_utils_end
+> **Note:** `sudef` is experimental. Features may not be fully tested. Please report any issues.
 
-*/
+---
+
+## Project Structure
+
 ```
-This will generate the same code as above but write it to a file named cfg_inc.svh and included by this file.
+icdk/
+├── src/uvmgen/
+│   ├── __init__.py              # Package metadata (__version__, __all__)
+│   ├── uvmgen.py                # UVMGen class & uvmgen CLI entry point
+│   ├── super_define.py          # sudef CLI entry point
+│   └── templates/               # Mako template files
+│       ├── agt_pkg/             # Agent package templates (11 files)
+│       ├── env_pkg/             # Environment package templates (5 files)
+│       ├── ral_pkg/             # Register abstraction layer templates
+│       ├── seq_lib_pkg/         # Sequence library templates (5 files)
+│       ├── test_pkg/            # Test package templates (3 files)
+│       └── tb_lib/              # Top-level testbench & filelist
+├── test/
+│   ├── json/
+│   │   ├── base_pkg/            # Single-package test configs (JSON/YAML/TOML/XML)
+│   │   └── example/             # Full testbench example config
+│   ├── super_define_data/       # sudef test fixtures
+│   ├── test_base.py             # End-to-end tests for uvmgen
+│   ├── test_example.py          # Full testbench generation tests
+│   └── test_super_define.py     # sudef unit tests
+├── .github/workflows/
+│   └── python-package.yml       # CI: lint (Ruff) + test (pytest) + build + deploy
+├── pyproject.toml               # Project metadata, dependencies, tool config
+├── requirements.txt             # Dev-only convenience requirements
+├── MANIFEST.in                  # Packaging include rules
+└── README.md
+```
+
+## Development
+
+### Setup
+
+```bash
+git clone https://github.com/Dragon-Git/icdk.git
+cd icdk
+python3 -m pip install -e '.[dev]'
+```
+
+This installs `ruff` (lint), `pytest` + `pytest-cov` (test), and `sphinx` (docs) in addition to the runtime dependencies.
+
+### Lint
+
+```bash
+ruff check .
+```
+
+### Test
+
+```bash
+pytest test/ -v --cov=uvmgen --cov-fail-under=60
+```
+
+### CI
+
+The [CI pipeline](https://github.com/Dragon-Git/icdk/actions/workflows/python-package.yml) runs on every push/PR to `master`:
+
+1. **Lint** with `astral-sh/ruff-action`
+2. **Test** across Python 3.9–3.13 on Ubuntu, macOS, and Windows
+3. **Coverage** reported to Codecov (threshold: 60%)
+4. **Build** wheel and sdist on tag push
+5. **Deploy** to PyPI on tag push
+
+---
 
 ## Contribute
-Contributions are always welcome! Simple fork this repo and submit a pull request.
+
+Contributions are always welcome! Fork this repo and submit a pull request.
+
+## License
+
+This project is licensed under the BSD-3-Clause License.


### PR DESCRIPTION
## 变更内容

全面重写 README.md，从原来的 181 行扩展到 451 行，新增以下内容：

### 新增章节

- **项目概述与关键特性**：介绍 icdk 定位、支持的配置格式、模板驱动架构、模块化包生成、第三方集成、Python 版本矩阵
- **安装指南**：区分 PyPI 安装和源码开发安装两种方式
- **配置文件格式参考**：
  - 包定义结构表（description / type / vars）
  - 支持的包类型对照表（6 种类型 → 模板目录 → 生成文件列表）
  - 四种格式（JSON/YAML/TOML/XML）的完整配置示例
- **模板变量参考表**：列出所有常用 vars 变量及其适用的包类型
- **生成输出目录结构**：展示典型 testbench 的目录树
- **仿真器运行指南**：VCS 和 Xcelium 的完整命令行示例
- **自定义模板指南**：如何使用自定义 Mako 模板目录
- **项目结构树**：完整的目录结构说明
- **开发指南**：安装、lint、测试、CI 流程
- **License 声明**

### 其他改进

- 添加 codecov badge
- 优化排版（表格、代码块、折叠区块）
- 补充 svlib/cluelib 的 GitHub 链接

### 验证

- `ruff check .`：**All checks passed!**
- `pytest test/`：**9 passed, 1 skipped**
